### PR TITLE
Simulations.

### DIFF
--- a/gforge/www/simulations/util_simulations.php
+++ b/gforge/www/simulations/util_simulations.php
@@ -276,21 +276,6 @@ function runSimulationJob($theRemoteServerName,
 	}
 
 
-	// Reserve remote server for simulation.
-	$statusAvail = reserveRemoteServer($theRemoteServerName, $theUserName, 
-		$theGroupId, $theJobTimeStamp, $theJobStartedTimeStamp, $theSoftwareName);
-	if ($statusAvail === false) {
-		// A script is already running. Do not proceed.
-		return "***INFO***" .  "Simulation job has been submitted. " .
-			"There is currently a job running at $theRemoteServerName.";
-	}
-	else if ($statusAvail !== true) {
-		// Has error. Do not proceed.
-		return $statusAvail;
-	}
-
-	// OK. Reserved remote server.
-
 	// Get group name.
 	$groupObj = group_get_object($theGroupId);
 	$groupName = $groupObj->getPublicName();
@@ -339,6 +324,21 @@ function runSimulationJob($theRemoteServerName,
 
 	// Record job started.
 	$status = recordRemoteServerJobStart($theRemoteServerName, $theUserName, $theGroupId, $theJobTimeStamp);
+
+	// Reserve remote server for simulation.
+	$statusAvail = reserveRemoteServer($theRemoteServerName, $theUserName, 
+		$theGroupId, $theJobTimeStamp, $theJobStartedTimeStamp, $theSoftwareName);
+	if ($statusAvail === false) {
+		// A script is already running. Do not proceed.
+		return "***INFO***" .  "Simulation job has been submitted. " .
+			"There is currently a job running at $theRemoteServerName.";
+	}
+	else if ($statusAvail !== true) {
+		// Has error. Do not proceed.
+		return $statusAvail;
+	}
+
+	// OK. Reserved remote server.
 
 
 	// Send configuration file if the config file is specified.
@@ -400,7 +400,7 @@ function runSimulationJob($theRemoteServerName,
 	$theSftp->disconnect();
 */
 
-	return "Simulation job request has been successfully submitted.";
+	return "Simulation job request has been successfully started.";
 }
 
 


### PR DESCRIPTION
- Updated util_simulations.php to address a timing issue. A simulation
job should only be in the simulation_requests table after the job has
started, but not when it was submitted.

Fixed:
https://simtk.org/tracker/index.php?func=detail&aid=2492&group_id=11&atid=1960