### PR TITLE
Downloads: GitHub archive

### DIFF
--- a/gforge/common/frs/FRSFile.class.php
+++ b/gforge/common/frs/FRSFile.class.php
@@ -494,7 +494,15 @@ class FRSFile extends Error {
 			return $this->data_array['filename'];
 		}
 		else {
-			return $this->data_array['simtk_filelocation'];
+			if ($this->data_array['simtk_filetype'] == 'GitHubArchive') {
+				// GitHub archive download uses simtk_filelocation
+				// for the URL, which is non-empty,
+				// and filename for the local filename.
+				return $this->data_array['filename'];
+			}
+			else {
+				return $this->data_array['simtk_filelocation'];
+			}
 		}
 	}
 


### PR DESCRIPTION
- Corrects getLocalFilename() to fetch from filename when GitHubArchive
is the filetype.