### PR TITLE
phpBB: inline attachments display order.

### DIFF
--- a/phpBB3/includes/functions_content.php
+++ b/phpBB3/includes/functions_content.php
@@ -975,17 +975,8 @@ function parse_attachments($forum_id, &$message, &$attachments, &$update_count, 
 		unset($new_attachment_data);
 	}
 
-	// Sort correctly
-	if ($config['display_order'])
-	{
-		// Ascending sort
-		krsort($attachments);
-	}
-	else
-	{
-		// Descending sort
-		ksort($attachments);
-	}
+	// Make sure attachments are properly ordered
+	ksort($attachments);
 
 	foreach ($attachments as $attachment)
 	{
@@ -1196,8 +1187,6 @@ function parse_attachments($forum_id, &$message, &$attachments, &$update_count, 
 	$attachments = $compiled_attachments;
 	unset($compiled_attachments);
 
-	$tpl_size = sizeof($attachments);
-
 	$unset_tpl = array();
 
 	preg_match_all('#<!\-\- ia([0-9]+) \-\->(.*?)<!\-\- ia\1 \-\->#', $message, $matches, PREG_PATTERN_ORDER);
@@ -1205,8 +1194,7 @@ function parse_attachments($forum_id, &$message, &$attachments, &$update_count, 
 	$replace = array();
 	foreach ($matches[0] as $num => $capture)
 	{
-		// Flip index if we are displaying the reverse way
-		$index = ($config['display_order']) ? ($tpl_size-($matches[1][$num] + 1)) : $matches[1][$num];
+		$index = $matches[1][$num];
 
 		$replace['from'][] = $matches[0][$num];
 		$replace['to'][] = (isset($attachments[$index])) ? $attachments[$index] : sprintf($user->lang['MISSING_INLINE_ATTACHMENT'], $matches[2][array_search($index, $matches[1])]);
@@ -1220,6 +1208,18 @@ function parse_attachments($forum_id, &$message, &$attachments, &$update_count, 
 	}
 
 	$unset_tpl = array_unique($unset_tpl);
+
+	// Sort correctly
+	if ($config['display_order'])
+	{
+		// Ascending sort
+		krsort($attachments);
+	}
+	else
+	{
+		// Descending sort
+		sort($attachments);
+	}
 
 	// Needed to let not display the inlined attachments at the end of the post again
 	foreach ($unset_tpl as $index)

--- a/phpBB3/posting.php
+++ b/phpBB3/posting.php
@@ -607,7 +607,7 @@ if ($post_data['post_attachment'] && !$submit && !$refresh && !$preview && $mode
 		WHERE post_msg_id = $post_id
 			AND in_message = 0
 			AND is_orphan = 0
-		ORDER BY filetime DESC";
+		ORDER BY attach_id DESC";
 	$result = $db->sql_query($sql);
 	$message_parser->attachment_data = array_merge($message_parser->attachment_data, $db->sql_fetchrowset($result));
 	$db->sql_freeresult($result);

--- a/phpBB3/viewtopic.php
+++ b/phpBB3/viewtopic.php
@@ -1409,7 +1409,7 @@ if (sizeof($attach_list))
 			FROM ' . ATTACHMENTS_TABLE . '
 			WHERE ' . $db->sql_in_set('post_msg_id', $attach_list) . '
 				AND in_message = 0
-			ORDER BY filetime DESC, post_msg_id ASC';
+			ORDER BY attach_id DESC, post_msg_id ASC';
 		$result = $db->sql_query($sql);
 
 		while ($row = $db->sql_fetchrow($result))


### PR DESCRIPTION
- Fixed order of inline attachments.
- Incorporated fix from phpBB v3.1.9
(https://github.com/phpbb/phpbb/pull/4190/files).
- New inline attachments will be placed in order correctly as shown in
preview, but pre-existing inline attachment order may still be
scrambled.

Fixed:
https://simtk.org/tracker/index.php?func=detail&aid=2523&group_id=11&atid=1960