### PR TITLE
Downloads: zip file generation.

### DIFF
--- a/gforge/common/frs/FRSPackage.class.php
+++ b/gforge/common/frs/FRSPackage.class.php
@@ -823,6 +823,14 @@ class FRSPackage extends Error {
 	}
 
 	public function createNewestReleaseFilesAsZip(){
+		// Do not generate zip file if Download Package button disabled.
+		if (!$this->isShowDownloadButton()) {
+			// NOTE: Remove the "latest" zip file if it is present.
+			$this->deleteNewestReleaseFilesAsZip();
+
+			return;
+		}
+
 		$release = $this->getNewestRelease();
 		$cntEmptyFiles = 0;
 		if ($release && class_exists('ZipArchive')) {


### PR DESCRIPTION
- Should not generate zip file when the Download Package button is
disabled. If the zip file is present, should remove it.

Fixed:
https://simtk.org/tracker/index.php?func=detail&aid=2533&group_id=11&atid=1960