### PR TITLE
[project creation] Short project identifier name.

### DIFF
--- a/fusionforge/common/include/account.php
+++ b/fusionforge/common/include/account.php
@@ -131,10 +131,16 @@ function account_groupnamevalid($name) {
 		return 0;
 	}
 
+/*
+	// Commented out check for presence of underscore character "_" 
+	// because the check for DNS name validation for the project identifier
+	// is not necessary and does not match with project identifier requirement 
+	// in the project creation page. 
 	if(preg_match("/_/",$name)) {
 		$GLOBALS['register_error'] = _('Group name cannot contain underscore for DNS reasons.');
 		return 0;
 	}
+*/
 
 	return 1;
 }


### PR DESCRIPTION
- Allowed underscore in "short project identifier" in new project creation.

Fixed:
https://simtk.org/tracker/index.php?func=detail&aid=3036&group_id=11&atid=1960