### PR TITLE
[Downloads] Feedback for file download.

### DIFF
--- a/fusionforge/www/frs/download_confirm.php
+++ b/fusionforge/www/frs/download_confirm.php
@@ -91,6 +91,9 @@ case 'file':
 	// Generate the page top.
 	generatePageTop($group_id, $expl_pathinfo);
 
+	// DIV containing the user fields.
+	echo "<div id='divUserInputs'>";
+
 	$showDownloadNotes = $frsFile->getShowNotes();
 	if ($showDownloadNotes > 0) {
 		genDownloadNotesUI($frsPackage);
@@ -112,6 +115,8 @@ case 'file':
 		// Prompt for mail list membership.
 		genMailListUI($listName);
 	}
+
+	echo "</div>";
 
 	if ($frsFile->getShowAgreement() > 0) {
 		// File shows agreement.
@@ -354,6 +359,18 @@ if (session_loggedin()) {
 $(document).ready(function() {
 	// Handle submit action.
 	$("#mySubmit").click(function() {
+
+		if ($(".expected_use").length) {
+			// Expected use textarea is present.
+			var valExpectedUse = $(".expected_use").val();
+			if ($.trim(valExpectedUse).length == 0 ||
+				valExpectedUse.length < 7) {
+				// Ignore submission. Expected use is not filled in.
+				$(".expected_use")[0].scrollIntoView(false);
+				return;
+			}
+		}
+
 		// Hide the license div, if present, once submitted.
 		$(".divLicense").hide();
 
@@ -372,6 +389,7 @@ $(document).ready(function() {
 		trackDownloadProgress("msgDownload", 
 			"myBrowse",
 			"mySubmit",
+			"divUserInputs",
 			tokenDownloadProgress);
 	});
 

--- a/fusionforge/www/frs/download_utils.php
+++ b/fusionforge/www/frs/download_utils.php
@@ -48,14 +48,12 @@ DEFINE('MSG_DOWNLOAD', '<div class="msgDownload"></div>');
 DEFINE('INPUT_TIMESTAMP', '<input type="hidden" name="timestamp" value="' . microtime(true) . '" />');
 
 DEFINE('INPUT_AGREED_SUBMIT', 
-	'<br/><p>Note: if the download does not start, make sure you have allowed pop-ups. In most browsers, you can do this by selecting the small icon to "allow pop-ups..." in the URL bar.  Once pop-ups are allowed, click the link again to download.</p>' .
 	'<input type="hidden" name="agreed" value="1" />' . '<br/>' .
 	'<input id="mySubmit" type="submit" name="submit" ' .
 	'value="I Agree & Download Now" class="btn-cta" />' . '&nbsp;' .
 	'<input id="myBrowse" type="submit" name="browse" value="Return to Download" class="btn-cta" />');
 
 DEFINE('INPUT_SUBMIT', 
-	'<br/><p>Note: if the download does not start, make sure you have allowed pop-ups. In most browsers, you can do this by selecting the small icon to "allow pop-ups..." in the URL bar.  Once pop-ups are allowed, click the link again to download.</p>' .
 	'<input type="hidden" name="agreed" value="0" />' . '<br/>' .
 	'<input id="mySubmit" type="submit" name="submit" ' .
 	'value="Download Now" class="btn-cta" />' . '&nbsp;' .
@@ -245,6 +243,8 @@ function generatePageTop($group_id, $expl_pathinfo) {
 	echo '<div style="display: table; width: 100%;">';
 	echo '<div class="main_col">';
 
+	echo MSG_DOWNLOAD;
+
 	// Generate form to collect user input before download.
 	// Add back "file", "file id", "file name" and "group id"
 	// to the URL to invoke with "download_start.php".
@@ -297,7 +297,6 @@ function genDownloadNotesUI($frsPackage) {
 
 // Generate UI for use agreement and Agreed & submit button.
 function genAgreedSubmitButton($frsPackage) {
-	echo MSG_DOWNLOAD;
 	// Display download agreement.
 	// Note: the custom agreement is the saved agreement.
 	// Note: Check to ensure use agreement is not 0 ("None") first.
@@ -316,7 +315,6 @@ function genAgreedSubmitButton($frsPackage) {
 
 // Generate UI for submit button.
 function genSubmitButton() {
-	echo MSG_DOWNLOAD;
 	echo INPUT_TIMESTAMP;
 	echo INPUT_SUBMIT;
 }

--- a/fusionforge/www/frs/utilsDownloadProgress.js
+++ b/fusionforge/www/frs/utilsDownloadProgress.js
@@ -34,10 +34,14 @@
 function trackDownloadProgress(divDownload,
 	divBrowse, 
 	divSubmit,
+	divUserInputs,
 	tokenDownloadProgress) {
 
 	// Hide submit button once download started.
 	$("#" + divSubmit).hide();
+
+	// Hide user input div once download started.
+	$("#" + divUserInputs).hide();
 
 	// Disable browse button.
 	$("#" + divBrowse).prop("disabled", true);


### PR DESCRIPTION
- Removed message on "Allow pop-ups..."
- Moved download progress message to top of page.
- If expected use is prompted and is empty, do not proceed.
- Hide user input fields after submittsion.

Fixed:
https://simtk.org/tracker/?func=detail&atid=1960&aid=2334&group_id=11